### PR TITLE
add saga legends NFTs

### DIFF
--- a/source/global/nfts.ts
+++ b/source/global/nfts.ts
@@ -181,6 +181,15 @@ export const ICP_NFT_LIST = [
     description: `500 years from now humans have long left earth and only the Robots remain. Robots have managed to create new identities often based on relics they have found from earths past.`,
     icon: 'https://bzsui-sqaaa-aaaah-qce2a-cai.raw.ic0.app/?cc=0&type=thumbnail&tokenid=rdlwm-kakor-uwiaa-aaaaa-b4arg-qaqca-aae4h-q',
   },
+  {
+    name: 'Saga Legends #1: The Fool',
+    id: 'nges7-giaaa-aaaaj-qaiya-cai',
+    standard: 'EXT',
+    isLive: true,
+    description:
+      '',
+    icon: 'https://nges7-giaaa-aaaaj-qaiya-cai.raw.ic0.app/assets/icon.png',
+  },
 ];
 
 const LIVE_ICP_NFT_LIST_CANISTER_IDS = ICP_NFT_LIST.filter(

--- a/source/global/nfts.ts
+++ b/source/global/nfts.ts
@@ -212,7 +212,7 @@ export const getTokenImageURL = (asset: keyable) => {
     if (asset?.canisterId === 'ahl3d-xqaaa-aaaaj-qacca-cai') {
       imageURL = `https://${asset?.canisterId}.raw.ic0.app/?cc=0&type=thumbnail&tokenid=${asset?.tokenIdentifier}`;
     } else {
-      imageURL = `https://${asset?.canisterId}.raw.ic0.app/?tokenid=${asset?.tokenIdentifier}`;
+      imageURL = `https://${asset?.canisterId}.raw.ic0.app/?type=thumbnail&tokenid=${asset?.tokenIdentifier}`;
     }
   }
   return imageURL;


### PR DESCRIPTION
This is a WIP. Adds Saga Legends NFTs. The issue is that the added NFT canister does not render properly in Earth Wallet. This is because the canister serves an html/application at each token's root path, instead of an image. I made this decision based on Plug and Stoic using the `type=thumbnail` query parameter to render NFTs within the wallet. I think this is worth discussing as a standards conversation. I believe it makes sense to allow for html responses at the root path for each token, because it allows for the NFT developer to link out to the various views offered by the NFT, whereas serving an image would require developers to find some other way to surface those views to end users. What would the Earth Wallet team's appetite be for using `type=thumbnail` to render NFTs in the wallet?